### PR TITLE
Imporve data saved in json file

### DIFF
--- a/src/canvas/__tests__/__snapshots__/Canvas.test.tsx.snap
+++ b/src/canvas/__tests__/__snapshots__/Canvas.test.tsx.snap
@@ -46,31 +46,43 @@ exports[`Canvas Canvas renders correctly 1`] = `
       },
       "LineGroup": Object {
         "line-592694": Object {
-          "from": <div
-            class="BlockGroup animate-appear react-draggable"
-            data="[object Object]"
-            style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(158px,256px);"
-          />,
+          "from": Object {
+            "bottom": 0,
+            "height": 0,
+            "left": 0,
+            "right": 0,
+            "top": 0,
+            "width": 0,
+          },
           "fromKey": "block-623187",
-          "to": <div
-            class="BlockGroup animate-appear react-draggable"
-            data="[object Object]"
-            style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(367px,368px);"
-          />,
+          "to": Object {
+            "bottom": 0,
+            "height": 0,
+            "left": 0,
+            "right": 0,
+            "top": 0,
+            "width": 0,
+          },
           "toKey": "block-624018",
         },
         "line-77619": Object {
-          "from": <div
-            class="BlockGroup animate-appear react-draggable"
-            data="[object Object]"
-            style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(253px,525px);"
-          />,
+          "from": Object {
+            "bottom": 0,
+            "height": 0,
+            "left": 0,
+            "right": 0,
+            "top": 0,
+            "width": 0,
+          },
           "fromKey": "block-73377",
-          "to": <div
-            class="BlockGroup animate-appear react-draggable"
-            data="[object Object]"
-            style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(158px,256px);"
-          />,
+          "to": Object {
+            "bottom": 0,
+            "height": 0,
+            "left": 0,
+            "right": 0,
+            "top": 0,
+            "width": 0,
+          },
           "toKey": "block-623187",
         },
       },
@@ -225,31 +237,43 @@ exports[`Canvas Canvas renders correctly 1`] = `
             },
             "LineGroup": Object {
               "line-592694": Object {
-                "from": <div
-                  class="BlockGroup animate-appear react-draggable"
-                  data="[object Object]"
-                  style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(158px,256px);"
-                />,
+                "from": Object {
+                  "bottom": 0,
+                  "height": 0,
+                  "left": 0,
+                  "right": 0,
+                  "top": 0,
+                  "width": 0,
+                },
                 "fromKey": "block-623187",
-                "to": <div
-                  class="BlockGroup animate-appear react-draggable"
-                  data="[object Object]"
-                  style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(367px,368px);"
-                />,
+                "to": Object {
+                  "bottom": 0,
+                  "height": 0,
+                  "left": 0,
+                  "right": 0,
+                  "top": 0,
+                  "width": 0,
+                },
                 "toKey": "block-624018",
               },
               "line-77619": Object {
-                "from": <div
-                  class="BlockGroup animate-appear react-draggable"
-                  data="[object Object]"
-                  style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(253px,525px);"
-                />,
+                "from": Object {
+                  "bottom": 0,
+                  "height": 0,
+                  "left": 0,
+                  "right": 0,
+                  "top": 0,
+                  "width": 0,
+                },
                 "fromKey": "block-73377",
-                "to": <div
-                  class="BlockGroup animate-appear react-draggable"
-                  data="[object Object]"
-                  style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(158px,256px);"
-                />,
+                "to": Object {
+                  "bottom": 0,
+                  "height": 0,
+                  "left": 0,
+                  "right": 0,
+                  "top": 0,
+                  "width": 0,
+                },
                 "toKey": "block-623187",
               },
             },
@@ -344,31 +368,43 @@ exports[`Canvas Canvas renders correctly 1`] = `
           lineData={
             Object {
               "line-592694": Object {
-                "from": <div
-                  class="BlockGroup animate-appear react-draggable"
-                  data="[object Object]"
-                  style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(158px,256px);"
-                />,
+                "from": Object {
+                  "bottom": 0,
+                  "height": 0,
+                  "left": 0,
+                  "right": 0,
+                  "top": 0,
+                  "width": 0,
+                },
                 "fromKey": "block-623187",
-                "to": <div
-                  class="BlockGroup animate-appear react-draggable"
-                  data="[object Object]"
-                  style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(367px,368px);"
-                />,
+                "to": Object {
+                  "bottom": 0,
+                  "height": 0,
+                  "left": 0,
+                  "right": 0,
+                  "top": 0,
+                  "width": 0,
+                },
                 "toKey": "block-624018",
               },
               "line-77619": Object {
-                "from": <div
-                  class="BlockGroup animate-appear react-draggable"
-                  data="[object Object]"
-                  style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(253px,525px);"
-                />,
+                "from": Object {
+                  "bottom": 0,
+                  "height": 0,
+                  "left": 0,
+                  "right": 0,
+                  "top": 0,
+                  "width": 0,
+                },
                 "fromKey": "block-73377",
-                "to": <div
-                  class="BlockGroup animate-appear react-draggable"
-                  data="[object Object]"
-                  style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(158px,256px);"
-                />,
+                "to": Object {
+                  "bottom": 0,
+                  "height": 0,
+                  "left": 0,
+                  "right": 0,
+                  "top": 0,
+                  "width": 0,
+                },
                 "toKey": "block-623187",
               },
             }
@@ -752,31 +788,43 @@ exports[`Canvas Canvas renders correctly 1`] = `
           data={
             Object {
               "line-592694": Object {
-                "from": <div
-                  class="BlockGroup animate-appear react-draggable"
-                  data="[object Object]"
-                  style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(158px,256px);"
-                />,
+                "from": Object {
+                  "bottom": 0,
+                  "height": 0,
+                  "left": 0,
+                  "right": 0,
+                  "top": 0,
+                  "width": 0,
+                },
                 "fromKey": "block-623187",
-                "to": <div
-                  class="BlockGroup animate-appear react-draggable"
-                  data="[object Object]"
-                  style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(367px,368px);"
-                />,
+                "to": Object {
+                  "bottom": 0,
+                  "height": 0,
+                  "left": 0,
+                  "right": 0,
+                  "top": 0,
+                  "width": 0,
+                },
                 "toKey": "block-624018",
               },
               "line-77619": Object {
-                "from": <div
-                  class="BlockGroup animate-appear react-draggable"
-                  data="[object Object]"
-                  style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(253px,525px);"
-                />,
+                "from": Object {
+                  "bottom": 0,
+                  "height": 0,
+                  "left": 0,
+                  "right": 0,
+                  "top": 0,
+                  "width": 0,
+                },
                 "fromKey": "block-73377",
-                "to": <div
-                  class="BlockGroup animate-appear react-draggable"
-                  data="[object Object]"
-                  style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(158px,256px);"
-                />,
+                "to": Object {
+                  "bottom": 0,
+                  "height": 0,
+                  "left": 0,
+                  "right": 0,
+                  "top": 0,
+                  "width": 0,
+                },
                 "toKey": "block-623187",
               },
             }

--- a/src/demo/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/src/demo/__tests__/__snapshots__/demo.test.tsx.snap
@@ -205,31 +205,43 @@ exports[`demo render correctly 1`] = `
           },
           "LineGroup": Object {
             "line-592694": Object {
-              "from": <div
-                class="BlockGroup animate-appear react-draggable"
-                data="[object Object]"
-                style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(158px,256px);"
-              />,
+              "from": Object {
+                "bottom": 0,
+                "height": 0,
+                "left": 0,
+                "right": 0,
+                "top": 0,
+                "width": 0,
+              },
               "fromKey": "block-623187",
-              "to": <div
-                class="BlockGroup animate-appear react-draggable"
-                data="[object Object]"
-                style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(367px,368px);"
-              />,
+              "to": Object {
+                "bottom": 0,
+                "height": 0,
+                "left": 0,
+                "right": 0,
+                "top": 0,
+                "width": 0,
+              },
               "toKey": "block-624018",
             },
             "line-77619": Object {
-              "from": <div
-                class="BlockGroup animate-appear react-draggable"
-                data="[object Object]"
-                style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(253px,525px);"
-              />,
+              "from": Object {
+                "bottom": 0,
+                "height": 0,
+                "left": 0,
+                "right": 0,
+                "top": 0,
+                "width": 0,
+              },
               "fromKey": "block-73377",
-              "to": <div
-                class="BlockGroup animate-appear react-draggable"
-                data="[object Object]"
-                style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(158px,256px);"
-              />,
+              "to": Object {
+                "bottom": 0,
+                "height": 0,
+                "left": 0,
+                "right": 0,
+                "top": 0,
+                "width": 0,
+              },
               "toKey": "block-623187",
             },
           },
@@ -379,31 +391,43 @@ exports[`demo render correctly 1`] = `
                 },
                 "LineGroup": Object {
                   "line-592694": Object {
-                    "from": <div
-                      class="BlockGroup animate-appear react-draggable"
-                      data="[object Object]"
-                      style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(158px,256px);"
-                    />,
+                    "from": Object {
+                      "bottom": 0,
+                      "height": 0,
+                      "left": 0,
+                      "right": 0,
+                      "top": 0,
+                      "width": 0,
+                    },
                     "fromKey": "block-623187",
-                    "to": <div
-                      class="BlockGroup animate-appear react-draggable"
-                      data="[object Object]"
-                      style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(367px,368px);"
-                    />,
+                    "to": Object {
+                      "bottom": 0,
+                      "height": 0,
+                      "left": 0,
+                      "right": 0,
+                      "top": 0,
+                      "width": 0,
+                    },
                     "toKey": "block-624018",
                   },
                   "line-77619": Object {
-                    "from": <div
-                      class="BlockGroup animate-appear react-draggable"
-                      data="[object Object]"
-                      style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(253px,525px);"
-                    />,
+                    "from": Object {
+                      "bottom": 0,
+                      "height": 0,
+                      "left": 0,
+                      "right": 0,
+                      "top": 0,
+                      "width": 0,
+                    },
                     "fromKey": "block-73377",
-                    "to": <div
-                      class="BlockGroup animate-appear react-draggable"
-                      data="[object Object]"
-                      style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(158px,256px);"
-                    />,
+                    "to": Object {
+                      "bottom": 0,
+                      "height": 0,
+                      "left": 0,
+                      "right": 0,
+                      "top": 0,
+                      "width": 0,
+                    },
                     "toKey": "block-623187",
                   },
                 },
@@ -496,31 +520,43 @@ exports[`demo render correctly 1`] = `
               lineData={
                 Object {
                   "line-592694": Object {
-                    "from": <div
-                      class="BlockGroup animate-appear react-draggable"
-                      data="[object Object]"
-                      style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(158px,256px);"
-                    />,
+                    "from": Object {
+                      "bottom": 0,
+                      "height": 0,
+                      "left": 0,
+                      "right": 0,
+                      "top": 0,
+                      "width": 0,
+                    },
                     "fromKey": "block-623187",
-                    "to": <div
-                      class="BlockGroup animate-appear react-draggable"
-                      data="[object Object]"
-                      style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(367px,368px);"
-                    />,
+                    "to": Object {
+                      "bottom": 0,
+                      "height": 0,
+                      "left": 0,
+                      "right": 0,
+                      "top": 0,
+                      "width": 0,
+                    },
                     "toKey": "block-624018",
                   },
                   "line-77619": Object {
-                    "from": <div
-                      class="BlockGroup animate-appear react-draggable"
-                      data="[object Object]"
-                      style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(253px,525px);"
-                    />,
+                    "from": Object {
+                      "bottom": 0,
+                      "height": 0,
+                      "left": 0,
+                      "right": 0,
+                      "top": 0,
+                      "width": 0,
+                    },
                     "fromKey": "block-73377",
-                    "to": <div
-                      class="BlockGroup animate-appear react-draggable"
-                      data="[object Object]"
-                      style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(158px,256px);"
-                    />,
+                    "to": Object {
+                      "bottom": 0,
+                      "height": 0,
+                      "left": 0,
+                      "right": 0,
+                      "top": 0,
+                      "width": 0,
+                    },
                     "toKey": "block-623187",
                   },
                 }
@@ -904,31 +940,43 @@ exports[`demo render correctly 1`] = `
               data={
                 Object {
                   "line-592694": Object {
-                    "from": <div
-                      class="BlockGroup animate-appear react-draggable"
-                      data="[object Object]"
-                      style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(158px,256px);"
-                    />,
+                    "from": Object {
+                      "bottom": 0,
+                      "height": 0,
+                      "left": 0,
+                      "right": 0,
+                      "top": 0,
+                      "width": 0,
+                    },
                     "fromKey": "block-623187",
-                    "to": <div
-                      class="BlockGroup animate-appear react-draggable"
-                      data="[object Object]"
-                      style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(367px,368px);"
-                    />,
+                    "to": Object {
+                      "bottom": 0,
+                      "height": 0,
+                      "left": 0,
+                      "right": 0,
+                      "top": 0,
+                      "width": 0,
+                    },
                     "toKey": "block-624018",
                   },
                   "line-77619": Object {
-                    "from": <div
-                      class="BlockGroup animate-appear react-draggable"
-                      data="[object Object]"
-                      style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(253px,525px);"
-                    />,
+                    "from": Object {
+                      "bottom": 0,
+                      "height": 0,
+                      "left": 0,
+                      "right": 0,
+                      "top": 0,
+                      "width": 0,
+                    },
                     "fromKey": "block-73377",
-                    "to": <div
-                      class="BlockGroup animate-appear react-draggable"
-                      data="[object Object]"
-                      style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(158px,256px);"
-                    />,
+                    "to": Object {
+                      "bottom": 0,
+                      "height": 0,
+                      "left": 0,
+                      "right": 0,
+                      "top": 0,
+                      "width": 0,
+                    },
                     "toKey": "block-623187",
                   },
                 }
@@ -949,41 +997,56 @@ exports[`demo render correctly 1`] = `
                   data={
                     Object {
                       "line-592694": Object {
-                        "from": <div
-                          class="BlockGroup animate-appear react-draggable"
-                          data="[object Object]"
-                          style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(158px,256px);"
-                        />,
+                        "from": Object {
+                          "bottom": 0,
+                          "height": 0,
+                          "left": 0,
+                          "right": 0,
+                          "top": 0,
+                          "width": 0,
+                        },
                         "fromKey": "block-623187",
-                        "to": <div
-                          class="BlockGroup animate-appear react-draggable"
-                          data="[object Object]"
-                          style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(367px,368px);"
-                        />,
+                        "to": Object {
+                          "bottom": 0,
+                          "height": 0,
+                          "left": 0,
+                          "right": 0,
+                          "top": 0,
+                          "width": 0,
+                        },
                         "toKey": "block-624018",
                       },
                       "line-77619": Object {
-                        "from": <div
-                          class="BlockGroup animate-appear react-draggable"
-                          data="[object Object]"
-                          style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(253px,525px);"
-                        />,
+                        "from": Object {
+                          "bottom": 0,
+                          "height": 0,
+                          "left": 0,
+                          "right": 0,
+                          "top": 0,
+                          "width": 0,
+                        },
                         "fromKey": "block-73377",
-                        "to": <div
-                          class="BlockGroup animate-appear react-draggable"
-                          data="[object Object]"
-                          style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(158px,256px);"
-                        />,
+                        "to": Object {
+                          "bottom": 0,
+                          "height": 0,
+                          "left": 0,
+                          "right": 0,
+                          "top": 0,
+                          "width": 0,
+                        },
                         "toKey": "block-623187",
                       },
                     }
                   }
                   from={
-                    <div
-                      class="BlockGroup animate-appear react-draggable"
-                      data="[object Object]"
-                      style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(253px,525px);"
-                    />
+                    Object {
+                      "bottom": 0,
+                      "height": 0,
+                      "left": 0,
+                      "right": 0,
+                      "top": 0,
+                      "width": 0,
+                    }
                   }
                   key="line-77619"
                   offset={
@@ -995,11 +1058,14 @@ exports[`demo render correctly 1`] = `
                   orientation="h"
                   style={Object {}}
                   to={
-                    <div
-                      class="BlockGroup animate-appear react-draggable"
-                      data="[object Object]"
-                      style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(158px,256px);"
-                    />
+                    Object {
+                      "bottom": 0,
+                      "height": 0,
+                      "left": 0,
+                      "right": 0,
+                      "top": 0,
+                      "width": 0,
+                    }
                   }
                 >
                   <div
@@ -1010,41 +1076,56 @@ exports[`demo render correctly 1`] = `
                       data={
                         Object {
                           "line-592694": Object {
-                            "from": <div
-                              class="BlockGroup animate-appear react-draggable"
-                              data="[object Object]"
-                              style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(158px,256px);"
-                            />,
+                            "from": Object {
+                              "bottom": 0,
+                              "height": 0,
+                              "left": 0,
+                              "right": 0,
+                              "top": 0,
+                              "width": 0,
+                            },
                             "fromKey": "block-623187",
-                            "to": <div
-                              class="BlockGroup animate-appear react-draggable"
-                              data="[object Object]"
-                              style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(367px,368px);"
-                            />,
+                            "to": Object {
+                              "bottom": 0,
+                              "height": 0,
+                              "left": 0,
+                              "right": 0,
+                              "top": 0,
+                              "width": 0,
+                            },
                             "toKey": "block-624018",
                           },
                           "line-77619": Object {
-                            "from": <div
-                              class="BlockGroup animate-appear react-draggable"
-                              data="[object Object]"
-                              style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(253px,525px);"
-                            />,
+                            "from": Object {
+                              "bottom": 0,
+                              "height": 0,
+                              "left": 0,
+                              "right": 0,
+                              "top": 0,
+                              "width": 0,
+                            },
                             "fromKey": "block-73377",
-                            "to": <div
-                              class="BlockGroup animate-appear react-draggable"
-                              data="[object Object]"
-                              style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(158px,256px);"
-                            />,
+                            "to": Object {
+                              "bottom": 0,
+                              "height": 0,
+                              "left": 0,
+                              "right": 0,
+                              "top": 0,
+                              "width": 0,
+                            },
                             "toKey": "block-623187",
                           },
                         }
                       }
                       from={
-                        <div
-                          class="BlockGroup animate-appear react-draggable"
-                          data="[object Object]"
-                          style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(253px,525px);"
-                        />
+                        Object {
+                          "bottom": 0,
+                          "height": 0,
+                          "left": 0,
+                          "right": 0,
+                          "top": 0,
+                          "width": 0,
+                        }
                       }
                       offset={
                         Object {
@@ -1055,11 +1136,14 @@ exports[`demo render correctly 1`] = `
                       orientation="h"
                       style={Object {}}
                       to={
-                        <div
-                          class="BlockGroup animate-appear react-draggable"
-                          data="[object Object]"
-                          style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(158px,256px);"
-                        />
+                        Object {
+                          "bottom": 0,
+                          "height": 0,
+                          "left": 0,
+                          "right": 0,
+                          "top": 0,
+                          "width": 0,
+                        }
                       }
                       x0={67}
                       x1={67}
@@ -1071,41 +1155,56 @@ exports[`demo render correctly 1`] = `
                         data={
                           Object {
                             "line-592694": Object {
-                              "from": <div
-                                class="BlockGroup animate-appear react-draggable"
-                                data="[object Object]"
-                                style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(158px,256px);"
-                              />,
+                              "from": Object {
+                                "bottom": 0,
+                                "height": 0,
+                                "left": 0,
+                                "right": 0,
+                                "top": 0,
+                                "width": 0,
+                              },
                               "fromKey": "block-623187",
-                              "to": <div
-                                class="BlockGroup animate-appear react-draggable"
-                                data="[object Object]"
-                                style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(367px,368px);"
-                              />,
+                              "to": Object {
+                                "bottom": 0,
+                                "height": 0,
+                                "left": 0,
+                                "right": 0,
+                                "top": 0,
+                                "width": 0,
+                              },
                               "toKey": "block-624018",
                             },
                             "line-77619": Object {
-                              "from": <div
-                                class="BlockGroup animate-appear react-draggable"
-                                data="[object Object]"
-                                style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(253px,525px);"
-                              />,
+                              "from": Object {
+                                "bottom": 0,
+                                "height": 0,
+                                "left": 0,
+                                "right": 0,
+                                "top": 0,
+                                "width": 0,
+                              },
                               "fromKey": "block-73377",
-                              "to": <div
-                                class="BlockGroup animate-appear react-draggable"
-                                data="[object Object]"
-                                style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(158px,256px);"
-                              />,
+                              "to": Object {
+                                "bottom": 0,
+                                "height": 0,
+                                "left": 0,
+                                "right": 0,
+                                "top": 0,
+                                "width": 0,
+                              },
                               "toKey": "block-623187",
                             },
                           }
                         }
                         from={
-                          <div
-                            class="BlockGroup animate-appear react-draggable"
-                            data="[object Object]"
-                            style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(253px,525px);"
-                          />
+                          Object {
+                            "bottom": 0,
+                            "height": 0,
+                            "left": 0,
+                            "right": 0,
+                            "top": 0,
+                            "width": 0,
+                          }
                         }
                         offset={
                           Object {
@@ -1116,11 +1215,14 @@ exports[`demo render correctly 1`] = `
                         orientation="h"
                         style={Object {}}
                         to={
-                          <div
-                            class="BlockGroup animate-appear react-draggable"
-                            data="[object Object]"
-                            style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(158px,256px);"
-                          />
+                          Object {
+                            "bottom": 0,
+                            "height": 0,
+                            "left": 0,
+                            "right": 0,
+                            "top": 0,
+                            "width": 0,
+                          }
                         }
                         x0={67}
                         x1={67}
@@ -1135,41 +1237,56 @@ exports[`demo render correctly 1`] = `
                             data={
                               Object {
                                 "line-592694": Object {
-                                  "from": <div
-                                    class="BlockGroup animate-appear react-draggable"
-                                    data="[object Object]"
-                                    style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(158px,256px);"
-                                  />,
+                                  "from": Object {
+                                    "bottom": 0,
+                                    "height": 0,
+                                    "left": 0,
+                                    "right": 0,
+                                    "top": 0,
+                                    "width": 0,
+                                  },
                                   "fromKey": "block-623187",
-                                  "to": <div
-                                    class="BlockGroup animate-appear react-draggable"
-                                    data="[object Object]"
-                                    style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(367px,368px);"
-                                  />,
+                                  "to": Object {
+                                    "bottom": 0,
+                                    "height": 0,
+                                    "left": 0,
+                                    "right": 0,
+                                    "top": 0,
+                                    "width": 0,
+                                  },
                                   "toKey": "block-624018",
                                 },
                                 "line-77619": Object {
-                                  "from": <div
-                                    class="BlockGroup animate-appear react-draggable"
-                                    data="[object Object]"
-                                    style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(253px,525px);"
-                                  />,
+                                  "from": Object {
+                                    "bottom": 0,
+                                    "height": 0,
+                                    "left": 0,
+                                    "right": 0,
+                                    "top": 0,
+                                    "width": 0,
+                                  },
                                   "fromKey": "block-73377",
-                                  "to": <div
-                                    class="BlockGroup animate-appear react-draggable"
-                                    data="[object Object]"
-                                    style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(158px,256px);"
-                                  />,
+                                  "to": Object {
+                                    "bottom": 0,
+                                    "height": 0,
+                                    "left": 0,
+                                    "right": 0,
+                                    "top": 0,
+                                    "width": 0,
+                                  },
                                   "toKey": "block-623187",
                                 },
                               }
                             }
                             from={
-                              <div
-                                class="BlockGroup animate-appear react-draggable"
-                                data="[object Object]"
-                                style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(253px,525px);"
-                              />
+                              Object {
+                                "bottom": 0,
+                                "height": 0,
+                                "left": 0,
+                                "right": 0,
+                                "top": 0,
+                                "width": 0,
+                              }
                             }
                             offset={
                               Object {
@@ -1193,11 +1310,14 @@ exports[`demo render correctly 1`] = `
                               }
                             }
                             to={
-                              <div
-                                class="BlockGroup animate-appear react-draggable"
-                                data="[object Object]"
-                                style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(158px,256px);"
-                              />
+                              Object {
+                                "bottom": 0,
+                                "height": 0,
+                                "left": 0,
+                                "right": 0,
+                                "top": 0,
+                                "width": 0,
+                              }
                             }
                           />
                         </div>
@@ -1210,41 +1330,56 @@ exports[`demo render correctly 1`] = `
                   data={
                     Object {
                       "line-592694": Object {
-                        "from": <div
-                          class="BlockGroup animate-appear react-draggable"
-                          data="[object Object]"
-                          style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(158px,256px);"
-                        />,
+                        "from": Object {
+                          "bottom": 0,
+                          "height": 0,
+                          "left": 0,
+                          "right": 0,
+                          "top": 0,
+                          "width": 0,
+                        },
                         "fromKey": "block-623187",
-                        "to": <div
-                          class="BlockGroup animate-appear react-draggable"
-                          data="[object Object]"
-                          style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(367px,368px);"
-                        />,
+                        "to": Object {
+                          "bottom": 0,
+                          "height": 0,
+                          "left": 0,
+                          "right": 0,
+                          "top": 0,
+                          "width": 0,
+                        },
                         "toKey": "block-624018",
                       },
                       "line-77619": Object {
-                        "from": <div
-                          class="BlockGroup animate-appear react-draggable"
-                          data="[object Object]"
-                          style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(253px,525px);"
-                        />,
+                        "from": Object {
+                          "bottom": 0,
+                          "height": 0,
+                          "left": 0,
+                          "right": 0,
+                          "top": 0,
+                          "width": 0,
+                        },
                         "fromKey": "block-73377",
-                        "to": <div
-                          class="BlockGroup animate-appear react-draggable"
-                          data="[object Object]"
-                          style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(158px,256px);"
-                        />,
+                        "to": Object {
+                          "bottom": 0,
+                          "height": 0,
+                          "left": 0,
+                          "right": 0,
+                          "top": 0,
+                          "width": 0,
+                        },
                         "toKey": "block-623187",
                       },
                     }
                   }
                   from={
-                    <div
-                      class="BlockGroup animate-appear react-draggable"
-                      data="[object Object]"
-                      style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(158px,256px);"
-                    />
+                    Object {
+                      "bottom": 0,
+                      "height": 0,
+                      "left": 0,
+                      "right": 0,
+                      "top": 0,
+                      "width": 0,
+                    }
                   }
                   key="line-592694"
                   offset={
@@ -1256,11 +1391,14 @@ exports[`demo render correctly 1`] = `
                   orientation="h"
                   style={Object {}}
                   to={
-                    <div
-                      class="BlockGroup animate-appear react-draggable"
-                      data="[object Object]"
-                      style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(367px,368px);"
-                    />
+                    Object {
+                      "bottom": 0,
+                      "height": 0,
+                      "left": 0,
+                      "right": 0,
+                      "top": 0,
+                      "width": 0,
+                    }
                   }
                 >
                   <div
@@ -1271,41 +1409,56 @@ exports[`demo render correctly 1`] = `
                       data={
                         Object {
                           "line-592694": Object {
-                            "from": <div
-                              class="BlockGroup animate-appear react-draggable"
-                              data="[object Object]"
-                              style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(158px,256px);"
-                            />,
+                            "from": Object {
+                              "bottom": 0,
+                              "height": 0,
+                              "left": 0,
+                              "right": 0,
+                              "top": 0,
+                              "width": 0,
+                            },
                             "fromKey": "block-623187",
-                            "to": <div
-                              class="BlockGroup animate-appear react-draggable"
-                              data="[object Object]"
-                              style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(367px,368px);"
-                            />,
+                            "to": Object {
+                              "bottom": 0,
+                              "height": 0,
+                              "left": 0,
+                              "right": 0,
+                              "top": 0,
+                              "width": 0,
+                            },
                             "toKey": "block-624018",
                           },
                           "line-77619": Object {
-                            "from": <div
-                              class="BlockGroup animate-appear react-draggable"
-                              data="[object Object]"
-                              style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(253px,525px);"
-                            />,
+                            "from": Object {
+                              "bottom": 0,
+                              "height": 0,
+                              "left": 0,
+                              "right": 0,
+                              "top": 0,
+                              "width": 0,
+                            },
                             "fromKey": "block-73377",
-                            "to": <div
-                              class="BlockGroup animate-appear react-draggable"
-                              data="[object Object]"
-                              style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(158px,256px);"
-                            />,
+                            "to": Object {
+                              "bottom": 0,
+                              "height": 0,
+                              "left": 0,
+                              "right": 0,
+                              "top": 0,
+                              "width": 0,
+                            },
                             "toKey": "block-623187",
                           },
                         }
                       }
                       from={
-                        <div
-                          class="BlockGroup animate-appear react-draggable"
-                          data="[object Object]"
-                          style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(158px,256px);"
-                        />
+                        Object {
+                          "bottom": 0,
+                          "height": 0,
+                          "left": 0,
+                          "right": 0,
+                          "top": 0,
+                          "width": 0,
+                        }
                       }
                       offset={
                         Object {
@@ -1316,11 +1469,14 @@ exports[`demo render correctly 1`] = `
                       orientation="h"
                       style={Object {}}
                       to={
-                        <div
-                          class="BlockGroup animate-appear react-draggable"
-                          data="[object Object]"
-                          style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(367px,368px);"
-                        />
+                        Object {
+                          "bottom": 0,
+                          "height": 0,
+                          "left": 0,
+                          "right": 0,
+                          "top": 0,
+                          "width": 0,
+                        }
                       }
                       x0={67}
                       x1={67}
@@ -1332,41 +1488,56 @@ exports[`demo render correctly 1`] = `
                         data={
                           Object {
                             "line-592694": Object {
-                              "from": <div
-                                class="BlockGroup animate-appear react-draggable"
-                                data="[object Object]"
-                                style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(158px,256px);"
-                              />,
+                              "from": Object {
+                                "bottom": 0,
+                                "height": 0,
+                                "left": 0,
+                                "right": 0,
+                                "top": 0,
+                                "width": 0,
+                              },
                               "fromKey": "block-623187",
-                              "to": <div
-                                class="BlockGroup animate-appear react-draggable"
-                                data="[object Object]"
-                                style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(367px,368px);"
-                              />,
+                              "to": Object {
+                                "bottom": 0,
+                                "height": 0,
+                                "left": 0,
+                                "right": 0,
+                                "top": 0,
+                                "width": 0,
+                              },
                               "toKey": "block-624018",
                             },
                             "line-77619": Object {
-                              "from": <div
-                                class="BlockGroup animate-appear react-draggable"
-                                data="[object Object]"
-                                style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(253px,525px);"
-                              />,
+                              "from": Object {
+                                "bottom": 0,
+                                "height": 0,
+                                "left": 0,
+                                "right": 0,
+                                "top": 0,
+                                "width": 0,
+                              },
                               "fromKey": "block-73377",
-                              "to": <div
-                                class="BlockGroup animate-appear react-draggable"
-                                data="[object Object]"
-                                style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(158px,256px);"
-                              />,
+                              "to": Object {
+                                "bottom": 0,
+                                "height": 0,
+                                "left": 0,
+                                "right": 0,
+                                "top": 0,
+                                "width": 0,
+                              },
                               "toKey": "block-623187",
                             },
                           }
                         }
                         from={
-                          <div
-                            class="BlockGroup animate-appear react-draggable"
-                            data="[object Object]"
-                            style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(158px,256px);"
-                          />
+                          Object {
+                            "bottom": 0,
+                            "height": 0,
+                            "left": 0,
+                            "right": 0,
+                            "top": 0,
+                            "width": 0,
+                          }
                         }
                         offset={
                           Object {
@@ -1377,11 +1548,14 @@ exports[`demo render correctly 1`] = `
                         orientation="h"
                         style={Object {}}
                         to={
-                          <div
-                            class="BlockGroup animate-appear react-draggable"
-                            data="[object Object]"
-                            style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(367px,368px);"
-                          />
+                          Object {
+                            "bottom": 0,
+                            "height": 0,
+                            "left": 0,
+                            "right": 0,
+                            "top": 0,
+                            "width": 0,
+                          }
                         }
                         x0={67}
                         x1={67}
@@ -1396,41 +1570,56 @@ exports[`demo render correctly 1`] = `
                             data={
                               Object {
                                 "line-592694": Object {
-                                  "from": <div
-                                    class="BlockGroup animate-appear react-draggable"
-                                    data="[object Object]"
-                                    style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(158px,256px);"
-                                  />,
+                                  "from": Object {
+                                    "bottom": 0,
+                                    "height": 0,
+                                    "left": 0,
+                                    "right": 0,
+                                    "top": 0,
+                                    "width": 0,
+                                  },
                                   "fromKey": "block-623187",
-                                  "to": <div
-                                    class="BlockGroup animate-appear react-draggable"
-                                    data="[object Object]"
-                                    style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(367px,368px);"
-                                  />,
+                                  "to": Object {
+                                    "bottom": 0,
+                                    "height": 0,
+                                    "left": 0,
+                                    "right": 0,
+                                    "top": 0,
+                                    "width": 0,
+                                  },
                                   "toKey": "block-624018",
                                 },
                                 "line-77619": Object {
-                                  "from": <div
-                                    class="BlockGroup animate-appear react-draggable"
-                                    data="[object Object]"
-                                    style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(253px,525px);"
-                                  />,
+                                  "from": Object {
+                                    "bottom": 0,
+                                    "height": 0,
+                                    "left": 0,
+                                    "right": 0,
+                                    "top": 0,
+                                    "width": 0,
+                                  },
                                   "fromKey": "block-73377",
-                                  "to": <div
-                                    class="BlockGroup animate-appear react-draggable"
-                                    data="[object Object]"
-                                    style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(158px,256px);"
-                                  />,
+                                  "to": Object {
+                                    "bottom": 0,
+                                    "height": 0,
+                                    "left": 0,
+                                    "right": 0,
+                                    "top": 0,
+                                    "width": 0,
+                                  },
                                   "toKey": "block-623187",
                                 },
                               }
                             }
                             from={
-                              <div
-                                class="BlockGroup animate-appear react-draggable"
-                                data="[object Object]"
-                                style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(158px,256px);"
-                              />
+                              Object {
+                                "bottom": 0,
+                                "height": 0,
+                                "left": 0,
+                                "right": 0,
+                                "top": 0,
+                                "width": 0,
+                              }
                             }
                             offset={
                               Object {
@@ -1454,11 +1643,14 @@ exports[`demo render correctly 1`] = `
                               }
                             }
                             to={
-                              <div
-                                class="BlockGroup animate-appear react-draggable"
-                                data="[object Object]"
-                                style="width: 100px; height: 80px; background: rgb(255, 153, 102); border-radius: 10px; border: 1px solid #aaa; transform: translate(367px,368px);"
-                              />
+                              Object {
+                                "bottom": 0,
+                                "height": 0,
+                                "left": 0,
+                                "right": 0,
+                                "top": 0,
+                                "width": 0,
+                              }
                             }
                           />
                         </div>

--- a/src/line/LineTo.tsx
+++ b/src/line/LineTo.tsx
@@ -103,17 +103,13 @@ export default class LineTo extends Component<LineToProps, LineToState> {
 
     const anchor0 = staticFromAnchor;
     const anchor1 = staticToAnchor;
-
-    const box0 = from.getBoundingClientRect();
-    const box1 = to.getBoundingClientRect();
-
     const offsetX = window.pageXOffset - offset.x;
     const offsetY = window.pageYOffset - offset.y;
 
-    const x0 = box0.left + box0.width * anchor0.x + offsetX;
-    const x1 = box1.left + box1.width * anchor1.x + offsetX;
-    const y0 = box0.top + box0.height * anchor0.y + offsetY;
-    const y1 = box1.top + box1.height * anchor1.y + offsetY;
+    const x0 = from.left + from.width * anchor0.x + offsetX;
+    const x1 = to.left + to.width * anchor1.x + offsetX;
+    const y0 = from.top + from.height * anchor0.y + offsetY;
+    const y1 = to.top + to.height * anchor1.y + offsetY;
 
     return { x0, y0, x1, y1 };
   };

--- a/src/line/__tests__/Line.test.tsx
+++ b/src/line/__tests__/Line.test.tsx
@@ -3,15 +3,19 @@ import { mount } from 'enzyme';
 import { SteppedLineTo } from '..';
 import 'nino-cli/scripts/setup';
 
-const from = document.createElement('div');
-from.innerHTML = `
-  <div style="position: absolute; top: 0px; left: 0px;">from</div>
-`;
+const from = {
+  width: 0,
+  height: 0,
+  left: 0,
+  top: 0,
+};
 
-const to = document.createElement('div');
-to.innerHTML = `
-<div style="position: absolute; top: 0px; left: 100px;">from</div>
-`;
+const to = {
+  width: 0,
+  height: 0,
+  left: 100,
+  top: 0,
+};
 
 describe('Line', () => {
   it('Line renders correctly', () => {
@@ -34,16 +38,10 @@ describe('Line', () => {
     );
     expect(wrapper).toMatchSnapshot();
 
-    const x0: string = wrapper
-      .find('SteppedLine')
-      .at(0)
-      .prop('x0');
+    const x0: string = wrapper.find('SteppedLine').prop('x0');
     expect(parseFloat(x0) + 100).toBe(0);
 
-    const y0: string = wrapper
-      .find('SteppedLine')
-      .at(0)
-      .prop('y0');
+    const y0: string = wrapper.find('SteppedLine').prop('y0');
     expect(parseFloat(y0) + 100).toBe(0);
   });
 });

--- a/src/line/__tests__/__snapshots__/Line.test.tsx.snap
+++ b/src/line/__tests__/__snapshots__/Line.test.tsx.snap
@@ -4,17 +4,12 @@ exports[`Line Line renders correctly 1`] = `
 <SteppedLineTo
   className=""
   from={
-    <div>
-      
-  
-      <div
-        style="position: absolute; top: 0px; left: 0px;"
-      >
-        from
-      </div>
-      
-
-    </div>
+    Object {
+      "height": 0,
+      "left": 0,
+      "top": 0,
+      "width": 0,
+    }
   }
   offset={
     Object {
@@ -25,17 +20,12 @@ exports[`Line Line renders correctly 1`] = `
   orientation="v"
   style={Object {}}
   to={
-    <div>
-      
-
-      <div
-        style="position: absolute; top: 0px; left: 100px;"
-      >
-        from
-      </div>
-      
-
-    </div>
+    Object {
+      "height": 0,
+      "left": 100,
+      "top": 0,
+      "width": 0,
+    }
   }
 >
   <div
@@ -44,17 +34,12 @@ exports[`Line Line renders correctly 1`] = `
     <SteppedLine
       className=""
       from={
-        <div>
-          
-  
-          <div
-            style="position: absolute; top: 0px; left: 0px;"
-          >
-            from
-          </div>
-          
-
-        </div>
+        Object {
+          "height": 0,
+          "left": 0,
+          "top": 0,
+          "width": 0,
+        }
       }
       offset={
         Object {
@@ -65,119 +50,250 @@ exports[`Line Line renders correctly 1`] = `
       orientation="v"
       style={Object {}}
       to={
-        <div>
-          
-
-          <div
-            style="position: absolute; top: 0px; left: 100px;"
-          >
-            from
-          </div>
-          
-
-        </div>
+        Object {
+          "height": 0,
+          "left": 100,
+          "top": 0,
+          "width": 0,
+        }
       }
       x0={0}
-      x1={0}
+      x1={100}
       y0={0}
       y1={0}
     >
-      <Line
-        className=""
-        from={
-          <div>
-            
-  
-            <div
-              style="position: absolute; top: 0px; left: 0px;"
-            >
-              from
-            </div>
-            
-
-          </div>
-        }
-        offset={
-          Object {
-            "x": 0,
-            "y": 0,
-          }
-        }
-        orientation="v"
-        style={Object {}}
-        to={
-          <div>
-            
-
-            <div
-              style="position: absolute; top: 0px; left: 100px;"
-            >
-              from
-            </div>
-            
-
-          </div>
-        }
-        x0={0}
-        x1={0}
-        y0={0}
-        y1={0}
+      <div
+        className="stepped-lineto"
       >
-        <div
-          className="line-placeholder"
+        <Line
+          className=""
+          from={
+            Object {
+              "height": 0,
+              "left": 0,
+              "top": 0,
+              "width": 0,
+            }
+          }
+          offset={
+            Object {
+              "x": 0,
+              "y": 0,
+            }
+          }
+          orientation="v"
+          style={Object {}}
+          to={
+            Object {
+              "height": 0,
+              "left": 100,
+              "top": 0,
+              "width": 0,
+            }
+          }
+          x0={0}
+          x1={0}
+          y0={0}
+          y1={0}
         >
           <div
-            className="line-placeholder-item"
-            from={
-              <div>
-                
-  
-                <div
-                  style="position: absolute; top: 0px; left: 0px;"
-                >
-                  from
-                </div>
-                
-
-              </div>
-            }
-            offset={
-              Object {
-                "x": 0,
-                "y": 0,
+            className="line-placeholder"
+          >
+            <div
+              className="line-placeholder-item"
+              from={
+                Object {
+                  "height": 0,
+                  "left": 0,
+                  "top": 0,
+                  "width": 0,
+                }
               }
-            }
-            orientation="v"
-            style={
-              Object {
-                "borderTopColor": "#ddd",
-                "borderTopStyle": "solid",
-                "borderTopWidth": 1,
-                "left": "0px",
-                "position": "absolute",
-                "top": "0px",
-                "transform": "rotate(0deg)",
-                "transformOrigin": "0 0",
-                "width": "0px",
-                "zIndex": "1",
+              offset={
+                Object {
+                  "x": 0,
+                  "y": 0,
+                }
               }
+              orientation="v"
+              style={
+                Object {
+                  "borderTopColor": "#ddd",
+                  "borderTopStyle": "solid",
+                  "borderTopWidth": 1,
+                  "left": "0px",
+                  "position": "absolute",
+                  "top": "0px",
+                  "transform": "rotate(0deg)",
+                  "transformOrigin": "0 0",
+                  "width": "0px",
+                  "zIndex": "1",
+                }
+              }
+              to={
+                Object {
+                  "height": 0,
+                  "left": 100,
+                  "top": 0,
+                  "width": 0,
+                }
+              }
+            />
+          </div>
+        </Line>
+        <Line
+          className=""
+          from={
+            Object {
+              "height": 0,
+              "left": 0,
+              "top": 0,
+              "width": 0,
             }
-            to={
-              <div>
-                
-
-                <div
-                  style="position: absolute; top: 0px; left: 100px;"
-                >
-                  from
-                </div>
-                
-
-              </div>
+          }
+          offset={
+            Object {
+              "x": 0,
+              "y": 0,
             }
-          />
-        </div>
-      </Line>
+          }
+          orientation="v"
+          style={Object {}}
+          to={
+            Object {
+              "height": 0,
+              "left": 100,
+              "top": 0,
+              "width": 0,
+            }
+          }
+          x0={100}
+          x1={100}
+          y0={0}
+          y1={0}
+        >
+          <div
+            className="line-placeholder"
+          >
+            <div
+              className="line-placeholder-item"
+              from={
+                Object {
+                  "height": 0,
+                  "left": 0,
+                  "top": 0,
+                  "width": 0,
+                }
+              }
+              offset={
+                Object {
+                  "x": 0,
+                  "y": 0,
+                }
+              }
+              orientation="v"
+              style={
+                Object {
+                  "borderTopColor": "#ddd",
+                  "borderTopStyle": "solid",
+                  "borderTopWidth": 1,
+                  "left": "100px",
+                  "position": "absolute",
+                  "top": "0px",
+                  "transform": "rotate(0deg)",
+                  "transformOrigin": "0 0",
+                  "width": "0px",
+                  "zIndex": "1",
+                }
+              }
+              to={
+                Object {
+                  "height": 0,
+                  "left": 100,
+                  "top": 0,
+                  "width": 0,
+                }
+              }
+            />
+          </div>
+        </Line>
+        <Line
+          className=""
+          from={
+            Object {
+              "height": 0,
+              "left": 0,
+              "top": 0,
+              "width": 0,
+            }
+          }
+          offset={
+            Object {
+              "x": 0,
+              "y": 0,
+            }
+          }
+          orientation="v"
+          style={Object {}}
+          to={
+            Object {
+              "height": 0,
+              "left": 100,
+              "top": 0,
+              "width": 0,
+            }
+          }
+          x0={-1}
+          x1={100}
+          y0={0}
+          y1={0}
+        >
+          <div
+            className="line-placeholder"
+          >
+            <div
+              className="line-placeholder-item"
+              from={
+                Object {
+                  "height": 0,
+                  "left": 0,
+                  "top": 0,
+                  "width": 0,
+                }
+              }
+              offset={
+                Object {
+                  "x": 0,
+                  "y": 0,
+                }
+              }
+              orientation="v"
+              style={
+                Object {
+                  "borderTopColor": "#ddd",
+                  "borderTopStyle": "solid",
+                  "borderTopWidth": 1,
+                  "left": "-1px",
+                  "position": "absolute",
+                  "top": "0px",
+                  "transform": "rotate(0deg)",
+                  "transformOrigin": "0 0",
+                  "width": "101px",
+                  "zIndex": "1",
+                }
+              }
+              to={
+                Object {
+                  "height": 0,
+                  "left": 100,
+                  "top": 0,
+                  "width": 0,
+                }
+              }
+            />
+          </div>
+        </Line>
+      </div>
     </SteppedLine>
   </div>
 </SteppedLineTo>
@@ -187,17 +303,12 @@ exports[`Line offset works well 1`] = `
 <SteppedLineTo
   className=""
   from={
-    <div>
-      
-  
-      <div
-        style="position: absolute; top: 0px; left: 0px;"
-      >
-        from
-      </div>
-      
-
-    </div>
+    Object {
+      "height": 0,
+      "left": 0,
+      "top": 0,
+      "width": 0,
+    }
   }
   offset={
     Object {
@@ -208,17 +319,12 @@ exports[`Line offset works well 1`] = `
   orientation="v"
   style={Object {}}
   to={
-    <div>
-      
-
-      <div
-        style="position: absolute; top: 0px; left: 100px;"
-      >
-        from
-      </div>
-      
-
-    </div>
+    Object {
+      "height": 0,
+      "left": 100,
+      "top": 0,
+      "width": 0,
+    }
   }
 >
   <div
@@ -227,17 +333,12 @@ exports[`Line offset works well 1`] = `
     <SteppedLine
       className=""
       from={
-        <div>
-          
-  
-          <div
-            style="position: absolute; top: 0px; left: 0px;"
-          >
-            from
-          </div>
-          
-
-        </div>
+        Object {
+          "height": 0,
+          "left": 0,
+          "top": 0,
+          "width": 0,
+        }
       }
       offset={
         Object {
@@ -248,119 +349,250 @@ exports[`Line offset works well 1`] = `
       orientation="v"
       style={Object {}}
       to={
-        <div>
-          
-
-          <div
-            style="position: absolute; top: 0px; left: 100px;"
-          >
-            from
-          </div>
-          
-
-        </div>
+        Object {
+          "height": 0,
+          "left": 100,
+          "top": 0,
+          "width": 0,
+        }
       }
       x0={-100}
-      x1={-100}
+      x1={0}
       y0={-100}
       y1={-100}
     >
-      <Line
-        className=""
-        from={
-          <div>
-            
-  
-            <div
-              style="position: absolute; top: 0px; left: 0px;"
-            >
-              from
-            </div>
-            
-
-          </div>
-        }
-        offset={
-          Object {
-            "x": 100,
-            "y": 100,
-          }
-        }
-        orientation="v"
-        style={Object {}}
-        to={
-          <div>
-            
-
-            <div
-              style="position: absolute; top: 0px; left: 100px;"
-            >
-              from
-            </div>
-            
-
-          </div>
-        }
-        x0={-100}
-        x1={-100}
-        y0={-100}
-        y1={-100}
+      <div
+        className="stepped-lineto"
       >
-        <div
-          className="line-placeholder"
+        <Line
+          className=""
+          from={
+            Object {
+              "height": 0,
+              "left": 0,
+              "top": 0,
+              "width": 0,
+            }
+          }
+          offset={
+            Object {
+              "x": 100,
+              "y": 100,
+            }
+          }
+          orientation="v"
+          style={Object {}}
+          to={
+            Object {
+              "height": 0,
+              "left": 100,
+              "top": 0,
+              "width": 0,
+            }
+          }
+          x0={-100}
+          x1={-100}
+          y0={-100}
+          y1={-100}
         >
           <div
-            className="line-placeholder-item"
-            from={
-              <div>
-                
-  
-                <div
-                  style="position: absolute; top: 0px; left: 0px;"
-                >
-                  from
-                </div>
-                
-
-              </div>
-            }
-            offset={
-              Object {
-                "x": 100,
-                "y": 100,
+            className="line-placeholder"
+          >
+            <div
+              className="line-placeholder-item"
+              from={
+                Object {
+                  "height": 0,
+                  "left": 0,
+                  "top": 0,
+                  "width": 0,
+                }
               }
-            }
-            orientation="v"
-            style={
-              Object {
-                "borderTopColor": "#ddd",
-                "borderTopStyle": "solid",
-                "borderTopWidth": 1,
-                "left": "-100px",
-                "position": "absolute",
-                "top": "-100px",
-                "transform": "rotate(0deg)",
-                "transformOrigin": "0 0",
-                "width": "0px",
-                "zIndex": "1",
+              offset={
+                Object {
+                  "x": 100,
+                  "y": 100,
+                }
               }
+              orientation="v"
+              style={
+                Object {
+                  "borderTopColor": "#ddd",
+                  "borderTopStyle": "solid",
+                  "borderTopWidth": 1,
+                  "left": "-100px",
+                  "position": "absolute",
+                  "top": "-100px",
+                  "transform": "rotate(0deg)",
+                  "transformOrigin": "0 0",
+                  "width": "0px",
+                  "zIndex": "1",
+                }
+              }
+              to={
+                Object {
+                  "height": 0,
+                  "left": 100,
+                  "top": 0,
+                  "width": 0,
+                }
+              }
+            />
+          </div>
+        </Line>
+        <Line
+          className=""
+          from={
+            Object {
+              "height": 0,
+              "left": 0,
+              "top": 0,
+              "width": 0,
             }
-            to={
-              <div>
-                
-
-                <div
-                  style="position: absolute; top: 0px; left: 100px;"
-                >
-                  from
-                </div>
-                
-
-              </div>
+          }
+          offset={
+            Object {
+              "x": 100,
+              "y": 100,
             }
-          />
-        </div>
-      </Line>
+          }
+          orientation="v"
+          style={Object {}}
+          to={
+            Object {
+              "height": 0,
+              "left": 100,
+              "top": 0,
+              "width": 0,
+            }
+          }
+          x0={0}
+          x1={0}
+          y0={-100}
+          y1={-100}
+        >
+          <div
+            className="line-placeholder"
+          >
+            <div
+              className="line-placeholder-item"
+              from={
+                Object {
+                  "height": 0,
+                  "left": 0,
+                  "top": 0,
+                  "width": 0,
+                }
+              }
+              offset={
+                Object {
+                  "x": 100,
+                  "y": 100,
+                }
+              }
+              orientation="v"
+              style={
+                Object {
+                  "borderTopColor": "#ddd",
+                  "borderTopStyle": "solid",
+                  "borderTopWidth": 1,
+                  "left": "0px",
+                  "position": "absolute",
+                  "top": "-100px",
+                  "transform": "rotate(0deg)",
+                  "transformOrigin": "0 0",
+                  "width": "0px",
+                  "zIndex": "1",
+                }
+              }
+              to={
+                Object {
+                  "height": 0,
+                  "left": 100,
+                  "top": 0,
+                  "width": 0,
+                }
+              }
+            />
+          </div>
+        </Line>
+        <Line
+          className=""
+          from={
+            Object {
+              "height": 0,
+              "left": 0,
+              "top": 0,
+              "width": 0,
+            }
+          }
+          offset={
+            Object {
+              "x": 100,
+              "y": 100,
+            }
+          }
+          orientation="v"
+          style={Object {}}
+          to={
+            Object {
+              "height": 0,
+              "left": 100,
+              "top": 0,
+              "width": 0,
+            }
+          }
+          x0={-101}
+          x1={0}
+          y0={-100}
+          y1={-100}
+        >
+          <div
+            className="line-placeholder"
+          >
+            <div
+              className="line-placeholder-item"
+              from={
+                Object {
+                  "height": 0,
+                  "left": 0,
+                  "top": 0,
+                  "width": 0,
+                }
+              }
+              offset={
+                Object {
+                  "x": 100,
+                  "y": 100,
+                }
+              }
+              orientation="v"
+              style={
+                Object {
+                  "borderTopColor": "#ddd",
+                  "borderTopStyle": "solid",
+                  "borderTopWidth": 1,
+                  "left": "-101px",
+                  "position": "absolute",
+                  "top": "-100px",
+                  "transform": "rotate(0deg)",
+                  "transformOrigin": "0 0",
+                  "width": "101px",
+                  "zIndex": "1",
+                }
+              }
+              to={
+                Object {
+                  "height": 0,
+                  "left": 100,
+                  "top": 0,
+                  "width": 0,
+                }
+              }
+            />
+          </div>
+        </Line>
+      </div>
     </SteppedLine>
   </div>
 </SteppedLineTo>

--- a/src/tools/BlockGroup.tsx
+++ b/src/tools/BlockGroup.tsx
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import ReactDOM from 'react-dom';
 import classNames from 'classnames';
 import Draggable from 'react-draggable';
 import { isSameCoordinate } from '../utils/commonUtil';
@@ -174,7 +173,9 @@ export default class BlockGroup extends Component<
   };
 
   saveBlock = (ref: HTMLDivElement | null, blockKey: string) => {
-    blockDOM[blockKey] = ReactDOM.findDOMNode(ref);
+    if (ref) {
+      blockDOM[blockKey] = ref.getBoundingClientRect();
+    }
   };
 
   shouldPaintLine = (checkBlockClickList: any, linesProps: any) => {

--- a/src/tools/LineGroup.tsx
+++ b/src/tools/LineGroup.tsx
@@ -48,7 +48,6 @@ export default class LineGroup extends Component<
     const { offset, ...rest } = this.props;
     return Object.keys(data).map(lineKey => {
       const { from, to } = data[lineKey];
-
       (window as any).DataCollector.set('LineGroup', {
         [lineKey]: omit(data[lineKey], ['from', 'to']),
       });


### PR DESCRIPTION
- [x] change `blockDOM` as a object from `getBoundingClientRect`, like { width: 0, height: 0, top: 0, left: 0 }. For `from` and `to` always render into tag like `<div from={object} to={object} />`, it's not intuitive.

Related to https://github.com/breathing-is-fun/mini-xmind/issues/26